### PR TITLE
Fix type from scala.sql to java.sql.

### DIFF
--- a/source/documentation/operations.html.md.erb
+++ b/source/documentation/operations.html.md.erb
@@ -8,7 +8,7 @@ title: Operations - ScalikeJDBC
 ### Query API
 <hr/>
 
-There are various query APIs. All of them (`single`, `first`, `list` and `foreach`) will execute `scala.sql.PreparedStatement#executeQuery()`.
+There are various query APIs. All of them (`single`, `first`, `list` and `foreach`) will execute `java.sql.PreparedStatement#executeQuery()`.
 
 <hr/>
 #### Single / Optional Result for Query
@@ -275,7 +275,7 @@ object Group extends SQLSyntaxSupport[Group] {
 ### Update API
 <hr/>
 
-`update` executes `scala.sql.PreparedStatement#executeUpdate()`.
+`update` executes `java.sql.PreparedStatement#executeUpdate()`.
 
 ```scala
 import scalikejdbc._
@@ -312,7 +312,7 @@ DB localTx { implicit s =>
 ### Execute API
 <hr/>
 
-`execute` executes `scala.sql.PreparedStatement#execute()`.
+`execute` executes `java.sql.PreparedStatement#execute()`.
 
 ```scala
 DB autoCommit { implicit session =>
@@ -326,7 +326,7 @@ DB autoCommit { implicit session =>
 ### Batch API
 <hr/>
 
-`batch` and `batchByName` executes `scala.sql.PreparedStatement#executeBatch()`.
+`batch` and `batchByName` executes `java.sql.PreparedStatement#executeBatch()`.
 
 ```scala
 import scalikejdbc._


### PR DESCRIPTION
I've noticed in the documentation that there were some references to `scala.sql.PreparedStatement` which I'd assume it should be `java.sql.PreparedStatement`. This was fixed only for the `documentation/1.x/operations.html.md.erb` page.