### PR TITLE
Document more clearly how `driver` setting is handled. 

### DIFF
--- a/source/documentation/configuration.html.md
+++ b/source/documentation/configuration.html.md
@@ -11,7 +11,7 @@ The following 3 things should be configured.
 ### Loading JDBC Drivers
 <hr/>
 
-In advance, JDBC drivers must be loaded by using
+In advance, some JDBC drivers must be loaded by using
 
 ```
 Class.forName(String)
@@ -22,6 +22,8 @@ or
 ```
 java.sql.DriverManager.registerDriver(java.sql.Driver)
 ```
+
+However many modern JDBC implementations will be automatically loaded when they are present on the classpath.
 
 If you use `scalikejdbc-config` or `scalikejdbc-play-plugin`, they do the legacy work for you.
 

--- a/source/documentation/configuration.html.md
+++ b/source/documentation/configuration.html.md
@@ -150,7 +150,9 @@ db.default.driver="org.postgresql.Driver"
 db.default.url="jdbc:postgresql://localhost:5432/scalikejdbc"
 ```
 
-After just calling `scalikejdbc.config.DBs.setupAll()`, Connection pools are prepared. `DBs.setup/DBs.setupAll` loads specified JDBC driver classes as well.
+After just calling `scalikejdbc.config.DBs.setupAll()`, Connection pools are prepared. `DBs.setup/DBs.setupAll` loads specified JDBC driver classes as well. 
+
+Note that due to the way JDBC works, these drivers are loaded globally for the entire JVM, and then a particular driver is selected from the global JVM list by locating the first which is able to handle the connection URL. This usually produces the expected behaviour anyway, unless you have multiple JDBC drivers in your classpath which handle the same URL (such as MySQL and MariaDB JDBC implementations, which both handle URLs of the form `jdbc:mysql:`). In these cases you may not get the implementation you are expecting, since the presence of JDBC packages in the classpath is, for many drivers, enough to have them registered globally.
 
 ```scala
 import scalikejdbc._


### PR DESCRIPTION
As discussed over at scalikejdbc/scalikejdbc#494, the `driver` setting doesn't work how you expect (although for most users, it will work fine). This updates (maybe in too much detail, would be better in a footnote) the documentation to explain that.