### PR TITLE
Changed a section of the connection pool documentation to correct the english 

### DIFF
--- a/source/documentation/connection-pool.html.md
+++ b/source/documentation/connection-pool.html.md
@@ -227,7 +227,7 @@ ConnectionPool.singleton(url, user, password,
 <hr/>
 #### commons-dbcp 1.x
 
-Formally, commons-dbcp 1.4 is the default connection pool of ScalikeJDBC. We don't recomment you using the older one now, but if you need to choose 1.4 instead due to some reasons, specifying `commons-dbcp` works for you.
+Previously, commons-dbcp 1.4 was the default connection pool for ScalikeJDBC. We don't recomment using the older one now, but if you need to choose 1.4 instead for some reason, specifying `commons-dbcp` works.
 
 ```scala
 ConnectionPool.singleton(url, user, password, 

--- a/source/documentation/sql-interpolation.html.md.erb
+++ b/source/documentation/sql-interpolation.html.md.erb
@@ -168,7 +168,7 @@ By Type Dynamic (SIP-17) since Scala 2.10.0, you can call undefined methods such
 
 When you call camel case fields, it will actually be transformed to column name as an underscore separated string. If column name doesn't exist in columns, `InvalidColumnNameException` will be thrown.
 
-Before that, the case case field name should be the same as any of the primary constructor arg names of type `A` of `SQLSyntaxSupport[A]`. The validation for this rule works in compilation phase with the power of Scala macros.
+Before that, the case field name should be the same as any of the primary constructor arg names of type `A` of `SQLSyntaxSupport[A]`. The validation for this rule works in compilation phase with the power of Scala macros.
 
 [http://docs.scala-lang.org/overviews/macros/overview.html](http://docs.scala-lang.org/overviews/macros/overview.html)
 

--- a/source/documentation/sql-interpolation.html.md.erb
+++ b/source/documentation/sql-interpolation.html.md.erb
@@ -52,7 +52,7 @@ Other values are mapped directly as `Object`s.
 ### SQLSyntax
 <hr/>
 
-`SQLSyntax` is not a binding parameter but a part of SQL. You can create a `SQLSyntax` object with sqls"" String interpolation.
+`SQLSyntax` is not a binding parameter but a part of the SQL. You can create a `SQLSyntax` object with sqls"" String interpolation.
 
 ```scala
 val ordering = if (isDesc) sqls"desc" else sqls"asc"


### PR DESCRIPTION
The documentation stated "Formally, commons-dbcp 1.4 is the default connection pool ...". I think this should have read "Formerly .." and it may be confusing to non native english speakers. I changed the paragraph a little to correct the grammar. I hope this helps! :-)