### PR TITLE
code golfed to simplify streamBy example

### DIFF
--- a/source/documentation/reactivestreams-support.html.md.erb
+++ b/source/documentation/reactivestreams-support.html.md.erb
@@ -39,9 +39,9 @@ object Company extends SQLSyntaxSupport[Company] {
 
   // 2. Make a StreamReadySQL object for create publisher.
   //    The StreamReadySQL is immutable, so you can reuse it like SQL object.
-  def streamBy(where: SQLSyntax): StreamReadySQL[Company] = {
+  def streamBy(condition: SQLSyntax): StreamReadySQL[Company] = {
     withSQL {
-      select.from(Company as m).where.append(sqls"${where}")
+      select.from(Company as m).where(condition)
     }.map(Company(m.resultName)).iterator()
   }
 }


### PR DESCRIPTION
We can write `streamBy` example more simply.
Thanks @seratch !

https://github.com/scalikejdbc/scalikejdbc/blob/3.0.2/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala#L53