### PR TITLE
version 3.2.0

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -62,8 +62,8 @@ set :markdown, fenced_code_blocks: true, smartypants: true, autolink: true, with
 I18n.enforce_available_locales = false
 
 # Latest versions
-@latest_version = "3.1.0"
-@latest_play_support_version = "2.6.0-scalikejdbc-3.1"
+@latest_version = "3.2.0"
+@latest_play_support_version = "2.6.0-scalikejdbc-3.2"
 @v2_play_support_version = "2.5.1"
 @v2_version = "2.5.2"
 @v1_version = "1.7.7"


### PR DESCRIPTION
- scalikejdbc 3.2.0 https://github.com/scalikejdbc/scalikejdbc/releases/tag/3.2.0
- scalikejdbc-play-support 2.6.0-scalikejdbc-3.2 https://github.com/scalikejdbc/scalikejdbc-play-support/commits/2.6-scalikejdbc-3.2