### PR TITLE
use java.time instead of joda-time in example

### DIFF
--- a/source/documentation/reverse-engineering.html.md
+++ b/source/documentation/reverse-engineering.html.md
@@ -50,28 +50,28 @@ package models
 import scalikejdbc._
 import java.time.{LocalDate, ZonedDateTime}
 
-case class Members(
+case class Member(
   id: Int,
   name: String,
   description: Option[String] = None,
   birthday: Option[LocalDate] = None,
   createdAt: ZonedDateTime) {
 
-  def save()(implicit session: DBSession = Members.autoSession): Members = Members.save(this)(session)
+  def save()(implicit session: DBSession = Member.autoSession): Member = Member.save(this)(session)
 
-  def destroy()(implicit session: DBSession = Members.autoSession): Int = Members.destroy(this)(session)
+  def destroy()(implicit session: DBSession = Member.autoSession): Int = Member.destroy(this)(session)
 
 }
 
 
-object Members extends SQLSyntaxSupport[Members] {
+object Member extends SQLSyntaxSupport[Member] {
 
-  override val tableName = "MEMBERS"
+  override val tableName = "MEMBER"
 
   override val columns = Seq("ID", "NAME", "DESCRIPTION", "BIRTHDAY", "CREATED_AT")
 
-  def apply(m: SyntaxProvider[Members])(rs: WrappedResultSet): Members = apply(m.resultName)(rs)
-  def apply(m: ResultName[Members])(rs: WrappedResultSet): Members = new Members(
+  def apply(m: SyntaxProvider[Member])(rs: WrappedResultSet): Member = apply(m.resultName)(rs)
+  def apply(m: ResultName[Member])(rs: WrappedResultSet): Member = new Member(
     id = rs.get(m.id),
     name = rs.get(m.name),
     description = rs.get(m.description),
@@ -79,39 +79,39 @@ object Members extends SQLSyntaxSupport[Members] {
     createdAt = rs.get(m.createdAt)
   )
 
-  val m = Members.syntax("m")
+  val m = Member.syntax("m")
 
   override val autoSession = AutoSession
 
-  def find(id: Int)(implicit session: DBSession = autoSession): Option[Members] = {
+  def find(id: Int)(implicit session: DBSession = autoSession): Option[Member] = {
     withSQL {
-      select.from(Members as m).where.eq(m.id, id)
-    }.map(Members(m.resultName)).single.apply()
+      select.from(Member as m).where.eq(m.id, id)
+    }.map(Member(m.resultName)).single.apply()
   }
 
-  def findAll()(implicit session: DBSession = autoSession): List[Members] = {
-    withSQL(select.from(Members as m)).map(Members(m.resultName)).list.apply()
+  def findAll()(implicit session: DBSession = autoSession): List[Member] = {
+    withSQL(select.from(Member as m)).map(Member(m.resultName)).list.apply()
   }
 
   def countAll()(implicit session: DBSession = autoSession): Long = {
-    withSQL(select(sqls.count).from(Members as m)).map(rs => rs.long(1)).single.apply().get
+    withSQL(select(sqls.count).from(Member as m)).map(rs => rs.long(1)).single.apply().get
   }
 
-  def findBy(where: SQLSyntax)(implicit session: DBSession = autoSession): Option[Members] = {
+  def findBy(where: SQLSyntax)(implicit session: DBSession = autoSession): Option[Member] = {
     withSQL {
-      select.from(Members as m).where.append(where)
-    }.map(Members(m.resultName)).single.apply()
+      select.from(Member as m).where.append(where)
+    }.map(Member(m.resultName)).single.apply()
   }
 
-  def findAllBy(where: SQLSyntax)(implicit session: DBSession = autoSession): List[Members] = {
+  def findAllBy(where: SQLSyntax)(implicit session: DBSession = autoSession): List[Member] = {
     withSQL {
-      select.from(Members as m).where.append(where)
-    }.map(Members(m.resultName)).list.apply()
+      select.from(Member as m).where.append(where)
+    }.map(Member(m.resultName)).list.apply()
   }
 
   def countBy(where: SQLSyntax)(implicit session: DBSession = autoSession): Long = {
     withSQL {
-      select(sqls.count).from(Members as m).where.append(where)
+      select(sqls.count).from(Member as m).where.append(where)
     }.map(_.long(1)).single.apply().get
   }
 
@@ -119,9 +119,9 @@ object Members extends SQLSyntaxSupport[Members] {
     name: String,
     description: Option[String] = None,
     birthday: Option[LocalDate] = None,
-    createdAt: ZonedDateTime)(implicit session: DBSession = autoSession): Members = {
+    createdAt: ZonedDateTime)(implicit session: DBSession = autoSession): Member = {
     val generatedKey = withSQL {
-      insert.into(Members).namedValues(
+      insert.into(Member).namedValues(
         column.name -> name,
         column.description -> description,
         column.birthday -> birthday,
@@ -129,7 +129,7 @@ object Members extends SQLSyntaxSupport[Members] {
       )
     }.updateAndReturnGeneratedKey.apply()
 
-    Members(
+    Member(
       id = generatedKey.toInt,
       name = name,
       description = description,
@@ -137,14 +137,14 @@ object Members extends SQLSyntaxSupport[Members] {
       createdAt = createdAt)
   }
 
-  def batchInsert(entities: Seq[Members])(implicit session: DBSession = autoSession): List[Int] = {
+  def batchInsert(entities: Seq[Member])(implicit session: DBSession = autoSession): List[Int] = {
     val params: Seq[Seq[(Symbol, Any)]] = entities.map(entity =>
       Seq(
         'name -> entity.name,
         'description -> entity.description,
         'birthday -> entity.birthday,
         'createdAt -> entity.createdAt))
-    SQL("""insert into MEMBERS(
+    SQL("""insert into MEMBER(
       NAME,
       DESCRIPTION,
       BIRTHDAY,
@@ -157,9 +157,9 @@ object Members extends SQLSyntaxSupport[Members] {
     )""").batchByName(params: _*).apply[List]()
   }
 
-  def save(entity: Members)(implicit session: DBSession = autoSession): Members = {
+  def save(entity: Member)(implicit session: DBSession = autoSession): Member = {
     withSQL {
-      update(Members).set(
+      update(Member).set(
         column.id -> entity.id,
         column.name -> entity.name,
         column.description -> entity.description,
@@ -170,8 +170,8 @@ object Members extends SQLSyntaxSupport[Members] {
     entity
   }
 
-  def destroy(entity: Members)(implicit session: DBSession = autoSession): Int = {
-    withSQL { delete.from(Members).where.eq(column.id, entity.id) }.update.apply()
+  def destroy(entity: Member)(implicit session: DBSession = autoSession): Int = {
+    withSQL { delete.from(Member).where.eq(column.id, entity.id) }.update.apply()
   }
 
 }
@@ -189,58 +189,58 @@ import scalikejdbc._
 import java.time.{LocalDate, ZonedDateTime}
 
 
-class MembersSpec extends Specification {
+class MemberSpec extends Specification {
 
-  "Members" should {
+  "Member" should {
 
-    val m = Members.syntax("m")
+    val m = Member.syntax("m")
 
     "find by primary keys" in new AutoRollback {
-      val maybeFound = Members.find(123)
+      val maybeFound = Member.find(123)
       maybeFound.isDefined should beTrue
     }
     "find by where clauses" in new AutoRollback {
-      val maybeFound = Members.findBy(sqls.eq(m.id, 123))
+      val maybeFound = Member.findBy(sqls.eq(m.id, 123))
       maybeFound.isDefined should beTrue
     }
     "find all records" in new AutoRollback {
-      val allResults = Members.findAll()
+      val allResults = Member.findAll()
       allResults.size should be_>(0)
     }
     "count all records" in new AutoRollback {
-      val count = Members.countAll()
+      val count = Member.countAll()
       count should be_>(0L)
     }
     "find all by where clauses" in new AutoRollback {
-      val results = Members.findAllBy(sqls.eq(m.id, 123))
+      val results = Member.findAllBy(sqls.eq(m.id, 123))
       results.size should be_>(0)
     }
     "count by where clauses" in new AutoRollback {
-      val count = Members.countBy(sqls.eq(m.id, 123))
+      val count = Member.countBy(sqls.eq(m.id, 123))
       count should be_>(0L)
     }
     "create new record" in new AutoRollback {
-      val created = Members.create(name = "MyString", createdAt = null)
+      val created = Member.create(name = "MyString", createdAt = null)
       created should not beNull
     }
     "save a record" in new AutoRollback {
-      val entity = Members.findAll().head
+      val entity = Member.findAll().head
       // TODO modify something
       val modified = entity
-      val updated = Members.save(modified)
+      val updated = Member.save(modified)
       updated should not equalTo(entity)
     }
     "destroy a record" in new AutoRollback {
-      val entity = Members.findAll().head
-      val deleted = Members.destroy(entity) == 1
+      val entity = Member.findAll().head
+      val deleted = Member.destroy(entity) == 1
       deleted should beTrue
-      val shouldBeNone = Members.find(123)
+      val shouldBeNone = Member.find(123)
       shouldBeNone.isDefined should beFalse
     }
     "perform batch insert" in new AutoRollback {
-      val entities = Members.findAll()
-      entities.foreach(e => Members.destroy(e))
-      val batchInserted = Members.batchInsert(entities)
+      val entities = Member.findAll()
+      entities.foreach(e => Member.destroy(e))
+      val batchInserted = Member.batchInsert(entities)
       batchInserted.size should be_>(0)
     }
   }

--- a/source/documentation/setup.html.md.erb
+++ b/source/documentation/setup.html.md.erb
@@ -117,7 +117,7 @@ generator.defaultAutoSession=true
 # Use autoConstruct macro (default: false)
 generator.autoConstruct=false
 # joda-time (org.joda.time.DateTime) or JSR-310 (java.time.ZonedDateTime java.time.OffsetDateTime java.time.LocalDateTime)
-generator.dateTimeClass=org.joda.time.DateTime
+generator.dateTimeClass=java.time.ZonedDateTime
 ```
 
 Usage: [/documentation/reverse-engineering](/documentation/reverse-engineering.html)

--- a/source/documentation/sql-interpolation.html.md.erb
+++ b/source/documentation/sql-interpolation.html.md.erb
@@ -271,7 +271,7 @@ object Member extends SQLSyntaxSupport[Member] {
 If you have multiple tables for same entity. For example, `orders_2011`, `orders_2012` and `orders_2013`.
 
 ```scala
-case class Order(id: Long, productId: Long, customerId: Option[Long], createdAt: DateTime)
+case class Order(id: Long, productId: Long, customerId: Option[Long], createdAt: ZonedDateTime)
 
 class OrderTable(val year: Int) extends SQLSyntaxSupport[Order] {
   // Be careful if you build tableName with input values
@@ -282,26 +282,26 @@ class OrderTable(val year: Int) extends SQLSyntaxSupport[Order] {
     id         = rs.long(o.id),
     productId  = rs.long(o.productId),
     customerId = rs.longOpt(o.customerId),
-    createdAt  = rs.jodaDateTime(o.createdAt)
+    createdAt  = rs.zonedDateTime(o.createdAt)
   )
 }
 val (o2011, o2012, o2013) = (new OrderTable(2011), new OrderTable(2012), new OrderTable(2013))
 
 val ordersIn2011 = DB readOnly { implicit s =>
   val o = o2011.syntax("o")
-  sql"select ${o.result.*} from ${o2011 as o) where ${o.customerId} is not null"
-    .map(o2011(o)).list.apply()
+  sql"select ${o.result.*} from ${o2011 as o} where ${o.customerId} is not null"
+    .map(o2011(o.resultName)).list.apply()
 }
 DB readOnly { implicit s =>
   val o2 = o2012.syntax("o")
   val ordersIn2012 =
-    sql"select ${o.result.*} from ${o2012 as o2) where ${o.customerId} is not null"
-      .map(o2012(o2)).list.apply()
+    sql"select ${o2.result.*} from ${o2012 as o2} where ${o2.customerId} is not null"
+      .map(o2012(o2.resultName)).list.apply()
 
   val o3 = o2013.syntax("o")
   val ordersIn2013 =
-    sql"select ${o.result.*} from ${o2013 as o3) where ${o.customerId} is not null"
-      .map(o2013(o3)).list.apply()
+    sql"select ${o3.result.*} from ${o2013 as o3} where ${o3.customerId} is not null"
+      .map(o2013(o3.resultName)).list.apply()
 }
 ```
 

--- a/source/documentation/testing.html.md
+++ b/source/documentation/testing.html.md
@@ -21,7 +21,6 @@ NOTICE: scalikejdbc-test is compatible with ScalaTest 2.0 or higher.
 ```scala
 import scalikejdbc._
 import scalikejdbc.scalatest.AutoRollback
-import org.joda.time.DateTime
 import org.scalatest.fixture.FlatSpec
 
 class AutoRollbackSpec extends FlatSpec with AutoRollback {
@@ -29,8 +28,8 @@ class AutoRollbackSpec extends FlatSpec with AutoRollback {
   // override def db = NamedDB('anotherdb).toDB
 
   override def fixture(implicit session: DBSession) {
-    sql"insert into members values (1, ${"Alice"}, ${DateTime.now})".update.apply()
-    sql"insert into members values (2, ${"Bob"}, ${DateTime.now})".update.apply()
+    sql"insert into members values (1, ${"Alice"}, current_timestamp)".update.apply()
+    sql"insert into members values (2, ${"Bob"}, current_timestamp)".update.apply()
   }
 
   behavior of "Members"
@@ -57,7 +56,6 @@ class AutoRollbackSpec extends FlatSpec with AutoRollback {
 ```scala
 import scalikejdbc._
 import scalikejdbc.specs2.mutable.AutoRollback
-import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 
 object MemberSpec extends Specification {
@@ -79,8 +77,8 @@ object MemberSpec extends Specification {
 trait AutoRollbackWithFixture extends AutoRollback {
   // override def db = NamedDB('db2).toDB
   override def fixture(implicit session: DBSession) {
-    sql"insert into members values (1, ${"Alice"}, ${DateTime.now})".update.apply()
-    sql"insert into members values (2, ${"Bob"}, ${DateTime.now})".update.apply()
+    sql"insert into members values (1, ${"Alice"}, current_timestamp)".update.apply()
+    sql"insert into members values (2, ${"Bob"}, current_timestamp)".update.apply()
   }
 }
 
@@ -93,7 +91,6 @@ trait AutoRollbackWithFixture extends AutoRollback {
 ```scala
 import scalikejdbc._
 import scalikejdbc.specs2.AutoRollback
-import org.joda.time.DateTime
 import org.specs2.Specification
 
 class MemberSpec extends Specification { def is =


### PR DESCRIPTION
I updated `reverse-engineering.html.md`.

I tried reverse engineering with `scalikejdbc 3.2.0`.

https://github.com/t-mochizuki/scalikejdbc-example/tree/topic-reverse-engineering-3.2.0

Related Issue is https://github.com/scalikejdbc/scalikejdbc.github.io/issues/58