### PR TITLE
update nokogiri dependency for security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,14 +89,14 @@ GEM
       middleman-core (~> 3.2)
       rouge (~> 1.0)
     mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.3.0)
     minitest (5.8.1)
     multi_json (1.11.2)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (3.0.1)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.12.5)
@@ -152,4 +152,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.3
+   1.16.1


### PR DESCRIPTION
Related issue is https://github.com/scalikejdbc/scalikejdbc.github.io/issues/60

I ran a command line `bundle update nokogiri`.

Is this right?