### PR TITLE
remove joda-time in example

### DIFF
--- a/source/documentation/operations.html.md.erb
+++ b/source/documentation/operations.html.md.erb
@@ -272,12 +272,12 @@ object Group extends SQLSyntaxSupport[Group] {
 import scalikejdbc._
 
 DB localTx { implicit session =>
-  sql"""insert into emp (id, name, created_at) values (${id}, ${name}, ${DateTime.now})"""
+  sql"""insert into emp (id, name, created_at) values (${id}, ${name}, current_timestamp)"""
     .update.apply()
-  val id = sql"insert into emp (name, created_at) values (${name}, current_timestamp)"
+  val newId = sql"insert into emp (name, created_at) values (${name}, current_timestamp)"
     .updateAndReturnGeneratedKey.apply()
-  sql"update emp set name = ${newName} where id = ${id}".update.apply()
-  sql"delete emp where id = ${id}".update.apply()
+  sql"update emp set name = ${newName} where id = ${newId}".update.apply()
+  sql"delete emp where id = ${newId}".update.apply()
 }
 
 val column = Emp.column
@@ -286,15 +286,15 @@ DB localTx { implicit s =>
     insert.into(Emp).namedValues(
       column.id -> id,
       column.name -> name,
-      column.createdAt -> DateTime.now)
+      column.createdAt -> sqls.currentTimestamp)
    }.update.apply()
 
-  val id: Long = withSQL {
-    insert.into(Empy).namedValues(column.name -> name, column.createdAt -> sqls.currentTimestamp)
+  val newId: Long = withSQL {
+    insert.into(Emp).namedValues(column.name -> name, column.createdAt -> sqls.currentTimestamp)
   }.updateAndReturnGeneratedKey.apply()
 
-  withSQL { update(Emp).set(column.name -> newName).where.eq(column.id, id) }.update.apply()
-  withSQL { delete.from(Emp).where.eq(column.id, id) }.update.apply()
+  withSQL { update(Emp).set(column.name -> newName).where.eq(column.id, newId) }.update.apply()
+  withSQL { delete.from(Emp).where.eq(column.id, newId) }.update.apply()
 }
 
 ```

--- a/source/documentation/query-dsl.html.md
+++ b/source/documentation/query-dsl.html.md
@@ -326,8 +326,10 @@ val preferredClients: List[(Int, Int)] = withSQL {
 <hr/>
 
 ```scala
+import java.time.ZonedDateTime
+
 withSQL {
-  insert.into(Member).values(1, "Alice", DateTime.now)
+  insert.into(Member).values(1, "Alice", ZonedDateTime.now)
 }.update.apply()
 
 // insert into members values (?, ?, ?)
@@ -335,9 +337,9 @@ withSQL {
 withSQL {
   val m = Member.column
   insert.into(Member).namedValues(
-    m.id -> 1, 
-    m.name -> "Alice", 
-    m.createdAt -> DateTime.now
+    m.id -> 1,
+    m.name -> "Alice",
+    m.createdAt -> ZonedDateTime.now
   )
 }.update.apply()
 
@@ -347,13 +349,15 @@ withSQL {
 Or `applyUpdate` is much simpler. But in some cases, applyUpdate causes compilation errors since Scala 2.10.1. This is not an issue of ScalikeJDBC. If you suffered it, use `withSQL { }.update.apply()` instead.
 
 ```scala
-applyUpdate { insert.into(Member).values(2, "Bob", DateTime.now) }
+import java.time.ZonedDateTime
+
+applyUpdate { insert.into(Member).values(2, "Bob", ZonedDateTime.now) }
 
 // insert into members values (?, ?, ?)
 
 val c = Member.column
 applyUpdate {
-  insert.into(Member).columns(c.id, c.name, c.createdAt).values(2, "Bob", DateTime.now)
+  insert.into(Member).columns(c.id, c.name, c.createdAt).values(2, "Bob", ZonedDateTime.now)
 }
 
 // insert into members (id, name, created_at) values (?, ?, ?)
@@ -394,14 +398,16 @@ withSQL {
 <hr/>
 
 ```scala
+import java.time.ZonedDateTime
+
 withSQL {
   update(Member).set(
     Member.column.name -> "Chris",
-    Member.column.updatedAt -> DateTime.now
+    Member.column.updatedAt -> ZonedDateTime.now
   ).where.eq(Member.column.id, 2)
 }.update.apply()
 
-// update members set name = ?, updated_at = ? 
+// update members set name = ?, updated_at = ?
 // where id = ?
 ```
 

--- a/source/documentation/sql-interpolation.html.md.erb
+++ b/source/documentation/sql-interpolation.html.md.erb
@@ -315,18 +315,19 @@ Just use normal class and implement `EntityEquality` trait (for one-to-many rela
 
 ```scala
 import scalikekdbc._
+import java.time.ZonedDateTime
 
 class HugeTable(
   val column1: Long,
   val column2: Option[String],
   val column3: String,
   val column4: Int,
-  val column5: DateTime,
+  val column5: ZonedDateTime,
   ...
   val column22: Int,
-  val column23: DateTime) extends EntityEquality {
+  val column23: ZonedDateTime) extends EntityEquality {
 
-  override val entityIdentity = Seq(column1, columns2, .., columns23).mkString("\t")
+  override val entityIdentity = Seq(column1, column2, ..., column23).mkString("\t")
 
 }
 ```


### PR DESCRIPTION
Related issue is https://github.com/scalikejdbc/scalikejdbc.github.io/issues/58

I removed the remaining DateTime. I forgot to remove it.

The following link is branches for the comfirmation.

- https://github.com/t-mochizuki/scalikejdbc-example/compare/topic-operations-3.2.0?expand=1
- https://github.com/t-mochizuki/scalikejdbc-example/compare/topic-query-dsl-3.2.0?expand=1
- https://github.com/t-mochizuki/scalikejdbc-example/compare/topic-sql-interpolation-3.2.0?expand=1
