### PR TITLE
fix configuration example for poolFactoryName to commons-dbcp2

### DIFF
--- a/source/documentation/configuration.html.md
+++ b/source/documentation/configuration.html.md
@@ -134,7 +134,7 @@ db.default.poolInitialSize=5
 db.default.poolMaxSize=7
 db.default.poolConnectionTimeoutMillis=1000
 db.default.poolValidationQuery="select 1 as one"
-db.default.poolFactoryName="commons-dbcp"
+db.default.poolFactoryName="commons-dbcp2"
 
 db.legacy.driver="org.h2.Driver"
 db.legacy.url="jdbc:h2:file:./db/db2"


### PR DESCRIPTION
fix configuration example for `poolFactoryName` from `commons-dbcp` to `commons-dbcp2`, as Scalikejdbc depends on `commons-dbcp2` which in return relies on code in the `commons-pool2` package. With old `poolFactoryName=commons-dbcp` setting `DBs.setup()` will fail with `java.lang.ClassNotFoundException: org.apache.commons.pool.ObjectPool`