### PR TITLE
Corrected the notation in the document that could easily be misleading

### DIFF
--- a/source/documentation/1.x/one-to-x.html.md
+++ b/source/documentation/1.x/one-to-x.html.md
@@ -75,7 +75,7 @@ val groups: Seq[Group] =
     .one(Group(m))
     .toManies(
        rs => Member.opt(g)(rs),
-       rs => Event(e)(rs))
+       rs => Event.opt(e)(rs))
      .map { (group, members, events) => group.copy(members = members, events = events) }
      .list
      .apply()

--- a/source/documentation/2.x/one-to-x.html.md
+++ b/source/documentation/2.x/one-to-x.html.md
@@ -75,7 +75,7 @@ val groups: Seq[Group] =
     .one(Group(m))
     .toManies(
        rs => Member.opt(g)(rs),
-       rs => Event(e)(rs))
+       rs => Event.opt(e)(rs))
      .map { (group, members, events) => group.copy(members = members, events = events) }
      .list
      .apply()

--- a/source/documentation/one-to-x.html.md
+++ b/source/documentation/one-to-x.html.md
@@ -75,7 +75,7 @@ val groups: Seq[Group] =
     .one(Group(m))
     .toManies(
        rs => Member.opt(g)(rs),
-       rs => Event(e)(rs))
+       rs => Event.opt(e)(rs))
      .map { (group, members, events) => group.copy(members = members, events = events) }
      .list
      .apply()


### PR DESCRIPTION
In the same document the method name of the companion object, which returns a type wrapped in Option type is "opt", so I unified it.