### PR TITLE
Add Txboundary example for Cats Effect

### DIFF
--- a/source/documentation/transaction.html.md
+++ b/source/documentation/transaction.html.md
@@ -212,7 +212,7 @@ import scalikejdbc._
 
 type A = ???
 
-def asyncExecution[A]: DBSession => MyIO[A] = ???
+def asyncExecution: DBSession => MyIO[A] = ???
 
 // default
 DB.localTx(asyncExecution)(boundary = myIOTxBoundary)

--- a/source/documentation/transaction.html.md
+++ b/source/documentation/transaction.html.md
@@ -237,7 +237,7 @@ import cats.effect._
 
 implicit def catsEffectIOTxBoundary[A]: TxBoundary[IO[A]] = new TxBoundary[IO[A]] {
   def finishTx(result: IO[A], tx: Tx): IO[A] =
-    result.guaranteeCase{
+    result.guaranteeCase {
       case ExitCase.Completed => IO(tx.commit())
       case _ => IO(tx.rollback())
     }
@@ -300,4 +300,3 @@ try {
   db.rollbackIfActive() // it NEVER throws Exception
 } finally { db.close() }
 ```
-

--- a/source/documentation/transaction.html.md
+++ b/source/documentation/transaction.html.md
@@ -229,7 +229,7 @@ NamedDB('named).localTx(asyncExecution)(boundary = myIOTxBoundary)
 
 *TxBoundary typeclass instance for cats.effect.IO[A]*
 
-`cats.effect.IO` has a cancellation mechanism, which `attempt` can't handle. Here, we use `guarantee`/`guaranteeCase` to make sure the finalizers are run.
+`cats.effect.IO` offers two ways to handle completion/cancellation as below. You can use `guaranteeCase` for commit/rollback operations while going with `guarantee` for connection closure.
 
 ```scala
 import scalikejdbc._
@@ -250,7 +250,7 @@ implicit def catsEffectIOTxBoundary[A]: TxBoundary[IO[A]] = new TxBoundary[IO[A]
 
 *localTx*
 
-Since `localTx` performs side-effects such as opening a connection before executing its body, `localTx` itself should be suspended in `IO`. Here, we use `IO.suspend` to achieve this:
+To take control of all the side-effects that happen in `localTx` method, you can use `suspend` method to wrap the code blocks using `localTx`.
 
 ```scala
 import scalikejdbc._
@@ -300,5 +300,4 @@ try {
   db.rollbackIfActive() // it NEVER throws Exception
 } finally { db.close() }
 ```
-
 

--- a/source/documentation/transaction.html.md
+++ b/source/documentation/transaction.html.md
@@ -170,7 +170,7 @@ sealed abstract class MyIO[+A] {
 }
 
 object MyIO {
-  def apply[A](a: => A): MyIO[A] = Delay(a _)
+  def apply[A](a: => A): MyIO[A] = Delay(() => a)
 
   final case class Delay[+A](thunk: () => A) extends MyIO[A]
 }

--- a/source/documentation/transaction.html.md
+++ b/source/documentation/transaction.html.md
@@ -136,8 +136,11 @@ val fResult = DB localTx { implicit s =>
 ### #Working with IO monads
 <hr/>
 
-*MyIO (IO monads minimal example)*
+<hr/>
+#### IO monads minimal example
+<hr/>
 
+*MyIO*
 
 ```scala
 sealed abstract class MyIO[+A] {
@@ -183,8 +186,8 @@ implicit def myIOTxBoundary[A]: TxBoundary[MyIO[A]] = new TxBoundary[MyIO[A]] {
 
   def finishTx(result: MyIO[A], tx: Tx): MyIO[A] = {
     result.attempt.flatMap {
-      case Right(_) => MyIO(tx.commit()).flatMap(_ => result)
-      case Left(_) => MyIO(tx.rollback()).flatMap(_ => result)
+      case Right(a) => MyIO(tx.commit()).flatMap(_ => MyIO(a))
+      case Left(e) => MyIO(tx.rollback()).flatMap(_ => MyIO(throw e))
     }
   }
 

--- a/source/documentation/transaction.html.md
+++ b/source/documentation/transaction.html.md
@@ -5,7 +5,7 @@ title: Transaction - ScalikeJDBC
 ## Transaction
 
 <hr/>
-### #readOnly block / session
+### readOnly block / session
 <hr/>
 
 Executes query in read-only mode.
@@ -33,7 +33,7 @@ DB readOnly { implicit session =>
 ```
 
 <hr/>
-### #autoCommit block / session
+### autoCommit block / session
 <hr/>
 
 Executes query / update in auto-commit mode.
@@ -55,7 +55,7 @@ try {
 ```
 
 <hr/>
-### #localTx block
+### localTx block
 <hr/>
 
 Executes query / update in block-scoped transactions.
@@ -88,7 +88,7 @@ val result: Try[Result] = DB localTx { implicit session =>
 Built-in type class instances are `Try`, `Either` and `Future`. You can use them by `import scalikejdbc.TxBoundary,***._`.
 
 <hr/>
-### #futureLocalTx block 
+### futureLocalTx block
 <hr/>
 
 `futureLocalTx` use `Future`'s state as transaction boundary. If one of the Future operations was failed, the transaction will perform rollback automatically. 
@@ -133,7 +133,7 @@ val fResult = DB localTx { implicit s =>
 ```
 
 <hr/>
-### #Working with IO monads
+### Working with IO monads
 <hr/>
 
 <hr/>
@@ -274,7 +274,7 @@ IO.suspend {
 
 
 <hr/>
-### #withinTx block / session
+### withinTx block / session
 <hr/>
 
 Executes query / update in already existing transactions.

--- a/source/documentation/transaction.html.md
+++ b/source/documentation/transaction.html.md
@@ -5,7 +5,7 @@ title: Transaction - ScalikeJDBC
 ## Transaction
 
 <hr/>
-### readOnly block / session
+### #readOnly block / session
 <hr/>
 
 Executes query in read-only mode.
@@ -33,7 +33,7 @@ DB readOnly { implicit session =>
 ```
 
 <hr/>
-### autoCommit block / session
+### #autoCommit block / session
 <hr/>
 
 Executes query / update in auto-commit mode.
@@ -55,7 +55,7 @@ try {
 ```
 
 <hr/>
-### localTx block
+### #localTx block
 <hr/>
 
 Executes query / update in block-scoped transactions.
@@ -88,7 +88,7 @@ val result: Try[Result] = DB localTx { implicit session =>
 Built-in type class instances are `Try`, `Either` and `Future`. You can use them by `import scalikejdbc.TxBoundary,***._`.
 
 <hr/>
-### futureLocalTx block
+### #futureLocalTx block 
 <hr/>
 
 `futureLocalTx` use `Future`'s state as transaction boundary. If one of the Future operations was failed, the transaction will perform rollback automatically. 
@@ -274,7 +274,7 @@ IO.suspend {
 
 
 <hr/>
-### withinTx block / session
+### #withinTx block / session
 <hr/>
 
 Executes query / update in already existing transactions.

--- a/source/documentation/transaction.html.md
+++ b/source/documentation/transaction.html.md
@@ -193,9 +193,10 @@ implicit def myIOTxBoundary[A]: TxBoundary[MyIO[A]] = new TxBoundary[MyIO[A]] {
 
   override def closeConnection(result: MyIO[A], doClose: () => Unit): MyIO[A] = {
     for {
-      x <- result
-      _ <- MyIO(doClose).map(x => x.apply())
-    } yield x
+      x <- result.attempt
+      _ <- MyIO(doClose())
+      a <- MyIO(x.fold(throw _, identity))
+    } yield a
   }
 }
 ```


### PR DESCRIPTION
Resolves #97 

Includes some minor fix-ups to the existing `MyIO` example.